### PR TITLE
UserRepositoryを実装中だったが、型だけを残す

### DIFF
--- a/TwitterClientApp.xcodeproj/project.pbxproj
+++ b/TwitterClientApp.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		C7DF941C1EFB51DB0058DF1B /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DF941B1EFB51DB0058DF1B /* LoginViewModel.swift */; };
 		C7E6D3591F00E96C00F105AD /* UserAPIDatastore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E6D3581F00E96C00F105AD /* UserAPIDatastore.swift */; };
 		C7E6D35B1F00F44300F105AD /* UserRealmDatastore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E6D35A1F00F44300F105AD /* UserRealmDatastore.swift */; };
+		C7E6D35D1F01058E00F105AD /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E6D35C1F01058E00F105AD /* UserRepository.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -95,6 +96,7 @@
 		C7DF941B1EFB51DB0058DF1B /* LoginViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		C7E6D3581F00E96C00F105AD /* UserAPIDatastore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAPIDatastore.swift; sourceTree = "<group>"; };
 		C7E6D35A1F00F44300F105AD /* UserRealmDatastore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRealmDatastore.swift; sourceTree = "<group>"; };
+		C7E6D35C1F01058E00F105AD /* UserRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,6 +179,7 @@
 				C7DF94201EFBF35C0058DF1B /* Service */,
 				C737A6041EFE40CD004CF23B /* Entities */,
 				C7C879CB1EF4F7D300E69DCD /* Frameworks */,
+				C7E6D35E1F0105CB00F105AD /* Repository */,
 			);
 			path = TwitterClientApp;
 			sourceTree = "<group>";
@@ -231,6 +234,14 @@
 				C784EE911EF77F3B008657A8 /* LoginViewController.swift */,
 			);
 			name = View;
+			sourceTree = "<group>";
+		};
+		C7E6D35E1F0105CB00F105AD /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				C7E6D35C1F01058E00F105AD /* UserRepository.swift */,
+			);
+			name = Repository;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -347,6 +358,7 @@
 				C7C8799C1EF4EC8700E69DCD /* AppDelegate.swift in Sources */,
 				C737A6031EFE1F47004CF23B /* User.swift in Sources */,
 				C7C879CF1EF5104600E69DCD /* TweetTimelineViewController.swift in Sources */,
+				C7E6D35D1F01058E00F105AD /* UserRepository.swift in Sources */,
 				C7E6D3591F00E96C00F105AD /* UserAPIDatastore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TwitterClientApp/UserAPIDatastore.swift
+++ b/TwitterClientApp/UserAPIDatastore.swift
@@ -11,40 +11,10 @@ import Foundation
 import RxSwift
 
 protocol UserAPIDatastoreType {
-    func getUsers(userID: Int, screenName: Int, includeEntities: Bool) -> Observable<[String: Any]>
 }
 
 struct UserAPIDatastore: UserAPIDatastoreType {
-    
-    func getUsers(userID: Int, screenName: Int, includeEntities: Bool)
-        -> Observable<[String: Any]> {
-            return UserRequest
-                .GetUsers(userID: userID, screenName: screenName)
-                .send()
-    }
 }
 
 fileprivate struct UserRequest {
-    
-    fileprivate struct GetUsers: TwitterRequestType {
-        
-        let userID: Int
-        let screenName: Int
-        let includeEntities = false
-        
-        let method = HTTPMethod.get
-        let path = "users/show.json"
-        
-        var parameters: Any? {
-            let params: [String: Any] = [
-                "user_id": userID,
-                "screen_name": screenName,
-                "include_entities": includeEntities
-            ]
-            return params
-        }
-        func response(from object: Any, urlResponse: HTTPURLResponse) throws -> [String: Any] {
-            return object as! [String: Any]
-        }
-    }
 }

--- a/TwitterClientApp/UserAPIDatastore.swift
+++ b/TwitterClientApp/UserAPIDatastore.swift
@@ -11,12 +11,12 @@ import Foundation
 import RxSwift
 
 protocol UserAPIDatastoreType {
-    static func getUsers(userID: Int, screenName: Int, includeEntities: Bool) -> Observable<[String: Any]>
+    func getUsers(userID: Int, screenName: Int, includeEntities: Bool) -> Observable<[String: Any]>
 }
 
 struct UserAPIDatastore: UserAPIDatastoreType {
     
-    static func getUsers(userID: Int, screenName: Int, includeEntities: Bool)
+    func getUsers(userID: Int, screenName: Int, includeEntities: Bool)
         -> Observable<[String: Any]> {
             return UserRequest
                 .GetUsers(userID: userID, screenName: screenName)

--- a/TwitterClientApp/UserRealmDatastore.swift
+++ b/TwitterClientApp/UserRealmDatastore.swift
@@ -10,7 +10,6 @@ import Foundation
 import Mapper
 
 protocol UserDatabaseDatastoreType {
-    func createOrUpdate(json: Any?, resetRelations: Bool, inTransaction: Bool) -> User?
 }
 
 struct UserRealmDatastore: RealmDatastore, UserDatabaseDatastoreType {
@@ -18,13 +17,6 @@ struct UserRealmDatastore: RealmDatastore, UserDatabaseDatastoreType {
     typealias TargetObject = User
     
     func map(json: NSDictionary, to object: TargetObject, resetRelations: Bool) throws -> TargetObject {
-        let map = Mapper(JSON: json)
-        
-        try object.twitterUserID = map.from("id")
-        try object.name = map.from("name")
-        try object.screenName = map.from("screen_name")
-        try object.profileImageURL = map.from("profile_image_url")
-        try object.profileImageURLHTTPS = map.from("profile_image_url_https")
         
         return object
     }

--- a/TwitterClientApp/UserRealmDatastore.swift
+++ b/TwitterClientApp/UserRealmDatastore.swift
@@ -17,7 +17,13 @@ struct UserRealmDatastore: RealmDatastore, UserDatabaseDatastoreType {
     typealias TargetObject = User
     
     func map(json: NSDictionary, to object: TargetObject, resetRelations: Bool) throws -> TargetObject {
+        let map = Mapper(JSON: json)
         
+        try object.twitterUserID = map.from("id")
+        try object.name = map.from("name")
+        try object.screenName = map.from("screen_name")
+        try object.profileImageURL = map.from("profile_image_url")
+        try object.profileImageURLHTTPS = map.from("profile_image_url_https")
         return object
     }
 }

--- a/TwitterClientApp/UserRealmDatastore.swift
+++ b/TwitterClientApp/UserRealmDatastore.swift
@@ -9,7 +9,11 @@
 import Foundation
 import Mapper
 
-struct UserRealmDatastore: RealmDatastore {
+protocol UserDatabaseDatastoreType {
+    func createOrUpdate(json: Any?, resetRelations: Bool, inTransaction: Bool) -> User?
+}
+
+struct UserRealmDatastore: RealmDatastore, UserDatabaseDatastoreType {
     
     typealias TargetObject = User
     

--- a/TwitterClientApp/UserRepository.swift
+++ b/TwitterClientApp/UserRepository.swift
@@ -1,0 +1,39 @@
+//
+//  UserRepository.swift
+//  TwitterClientApp
+//
+//  Created by Shoichi Kanzaki on 2017/06/26.
+//  Copyright © 2017年 mycompany. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+protocol UserRespositoryType {
+    func getUsers(userID: Int, screenName: Int, includeEntities: Bool) -> Observable<Void>
+}
+
+struct UserRespository: UserRespositoryType {
+    
+    fileprivate let apiDatastore: UserAPIDatastoreType
+    fileprivate let databaseDatastore: UserDatabaseDatastoreType
+    
+    init(apiDatastore: UserAPIDatastoreType, databaseDatastore: UserDatabaseDatastoreType) {
+        self.apiDatastore = apiDatastore
+        self.databaseDatastore = databaseDatastore
+    }
+    
+    func getUsers(userID: Int, screenName: Int, includeEntities: Bool) -> Observable<Void> {
+        return apiDatastore
+            .getUsers(
+                userID: userID, screenName: screenName, includeEntities: includeEntities
+        )
+            .do(onNext: { (json) in
+                guard let user = self.databaseDatastore.createOrUpdate(json: json["user"], resetRelations: true, inTransaction: false) else {
+                    return 
+                }
+                
+                })
+                .map { _ in }
+    }
+}

--- a/TwitterClientApp/UserRepository.swift
+++ b/TwitterClientApp/UserRepository.swift
@@ -10,7 +10,6 @@ import Foundation
 import RxSwift
 
 protocol UserRespositoryType {
-    func getUsers(userID: Int, screenName: Int, includeEntities: Bool) -> Observable<Void>
 }
 
 struct UserRespository: UserRespositoryType {
@@ -21,19 +20,5 @@ struct UserRespository: UserRespositoryType {
     init(apiDatastore: UserAPIDatastoreType, databaseDatastore: UserDatabaseDatastoreType) {
         self.apiDatastore = apiDatastore
         self.databaseDatastore = databaseDatastore
-    }
-    
-    func getUsers(userID: Int, screenName: Int, includeEntities: Bool) -> Observable<Void> {
-        return apiDatastore
-            .getUsers(
-                userID: userID, screenName: screenName, includeEntities: includeEntities
-        )
-            .do(onNext: { (json) in
-                guard let user = self.databaseDatastore.createOrUpdate(json: json["user"], resetRelations: true, inTransaction: false) else {
-                    return 
-                }
-                
-                })
-                .map { _ in }
     }
 }


### PR DESCRIPTION
## 関連イシュー
なし

## 注意点
- UserAPIDatastore, UserRealmDatastore, UserRepositoryの役割が今回のタイムライン表示では不要だったため、型だけを残しました。
- TweetRealmDatabaseでTweetとUserを紐づけて保存する実装に次は取り組みたいと思います。

## 特にレビューして欲しいポイント

## セルフレビュー
- コード規約にそっていないところはないか
- 不要な空行・空白は存在しないか