### PR TITLE
added git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj merge=union


### PR DESCRIPTION
mergeの際、ファイル自体の追加や削除や名前変更を管理するプロジェクトファイルのconflictをなくすために.gitattributesに記述。